### PR TITLE
Accessibility Issue Fix: Added <li> elements for component and demo cards

### DIFF
--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -294,7 +294,7 @@ export class AppHome extends LitElement {
             ${
         this.featured?.map((comp) => {
           return html`
-                  <comp-card .comp=${comp}></comp-card>
+                  <li><comp-card .comp=${comp}></comp-card></li>
                 `
         })
         }

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -304,7 +304,7 @@ export class AppHome extends LitElement {
         ${this.cat === null ? html`<ul id="compList">
           ${this.comps?.length > 0 ? html `${this.comps?.map((comp) => {
           return html`
-                <comp-card .comp=${comp}></comp-card>
+                <li><comp-card .comp=${comp}></comp-card></li>
               `
         })}` : html `<h2 id="noresults" role="alert">No results found</h2>`
         }
@@ -317,7 +317,7 @@ export class AppHome extends LitElement {
               ${
         this.demos?.length > 0 ? html `${this.demos?.map((demo) => {
           return html`
-                    <demo-card .demo=${demo}></demo-card>
+                    <li><demo-card .demo=${demo}></demo-card></li>
                   `
         })}` : html `<h2 id="noresults" role="alert">No results found</h2>`
         }


### PR DESCRIPTION
Fixes
https://github.com/pwa-builder/PWABuilder/issues/829

PR Type
Accessibility Issue Fix

Describe the current behavior?
The featured component cards, and the component and demo cards displayed in search results are within a ul element, but not in li elements. 

Describe the new behavior?
The behaviour and appearance is the same. However, the component and demo cards are enclosed within li elements. 