### PR TITLE
Accessibility Issue Fix: Added alt tags for images and tabindex tags for non-focused elements

### DIFF
--- a/src/script/pages/comp-detail.ts
+++ b/src/script/pages/comp-detail.ts
@@ -494,7 +494,7 @@ export class CompDetail extends LitElement {
                 <button id="installButton" @click="${this.installComp}">
                   Install Component
 
-                  <img src="/assets/down.svg">
+                  <img src="/assets/down.svg" alt="dropdown">
 
                   ${this.showOptions ? html`<div id="installOptions">
                     <button @click="${() => this.copyInstall("script")}">

--- a/src/script/pages/demo-detail.ts
+++ b/src/script/pages/demo-detail.ts
@@ -348,20 +348,20 @@ export class DemoDetail extends LitElement {
         </section>
 
         ${!this.demo?.video_url && this.demo?.screenshot_url ? html`<section id="demo">
-          <img .src="${this.demo?.screenshot_url}">
+          <img .src="${this.demo?.screenshot_url}" alt="screenshot of demo" tabindex="0">
         </section>` : null}
 
-        ${this.demo?.video_url ? html`<iframe id="mobileDemoVid" width="560" height="315" src="${this.demo?.video_url}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>` : null}
+        ${this.demo?.video_url ? html`<iframe tabindex="0" id="mobileDemoVid" width="560" height="315" src="${this.demo?.video_url}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>` : null}
 
         ${
           this.demo?.support ? html`
             <section id="support">
-              <browser-support .supportData="${this.demo?.support}"></browser-support>
+              <browser-support .supportData="${this.demo?.support}" tabindex="0"></browser-support>
             </section>
           ` : null
         }
 
-        ${this.readme ? html`<section id="readme" .innerHTML="${this.readme}"></section>` : null}
+        ${this.readme ? html`<section id="readme" .innerHTML="${this.readme}" tabindex="0"></section>` : null}
       </div>
     `;
   }


### PR DESCRIPTION
Fixes
https://github.com/pwa-builder/PWABuilder/issues/841

Added alt tags for images in components and demos that were missing it. Also added ta

bindex="0" for elements that 


PR Type
Accessibility Issue Fix

Describe the current behavior?
- The down icon in the "Install Component" button does not have an alt tag.
- The screenshot image for demos does not have an alt tag and is not focusable by a screen reader.
- The browser supported and readme sections are not focusable by a screen reader.

Describe the new behavior?
- The down icon in the "Install Component" button now has alt="dropdown".
- The screenshot image for demos now has a generic alt="screenshot of demo", and is focusable by a screen reader.
- The browser supported and readme sections are now focusable by a screen reader.