### PR TITLE
Accessibility Issue Fix: Added focus outline for Header elements, and Component and Demo buttons

### DIFF
--- a/src/script/components/header.ts
+++ b/src/script/components/header.ts
@@ -99,11 +99,11 @@ export class AppHeader extends LitElement {
   render() {
     return html`
       <header>
-        <img @click="${this.gobuilder}" id="icon" src="/assets/pwabuilder.svg" alt="PWABuilder icon">
+        <img @click="${this.gobuilder}" id="icon" src="/assets/pwabuilder.svg" alt="PWABuilder icon" tabindex="0">
 
         <div id="tabs">
-          <a id="hubLink" @click="${this.gobuilder}">My Hub</a>
-          <a href="/">Feature Store</a>
+          <a id="hubLink" @click="${this.gobuilder}" tabindex="0">My Hub</a>
+          <a href="/" tabindex="0">Feature Store</a>
         </div>
 
         <div id="github">

--- a/src/script/components/header.ts
+++ b/src/script/components/header.ts
@@ -62,6 +62,14 @@ export class AppHeader extends LitElement {
         width: 86px;
       }
 
+      #hubLink:focus {
+        outline: auto
+      }
+
+      #featureStore:focus {
+        outline: auto
+      }
+
       @media(max-width: 800px) {
         header #tabs {
           margin-left: 2em;
@@ -103,7 +111,7 @@ export class AppHeader extends LitElement {
 
         <div id="tabs">
           <a id="hubLink" @click="${this.gobuilder}" tabindex="0">My Hub</a>
-          <a href="/" tabindex="0">Feature Store</a>
+          <a id="featureStore" href="/" tabindex="0">Feature Store</a>
         </div>
 
         <div id="github">

--- a/src/script/components/header.ts
+++ b/src/script/components/header.ts
@@ -63,11 +63,11 @@ export class AppHeader extends LitElement {
       }
 
       #hubLink:focus {
-        outline: auto
+        outline: auto;
       }
 
       #featureStore:focus {
-        outline: auto
+        outline: auto;
       }
 
       @media(max-width: 800px) {

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -122,6 +122,11 @@ export class AppHome extends LitElement {
         width: 28em;
       }
 
+      #categoryButton:focus {
+        outline: auto;
+        outline-color: black;
+      }
+
       #searchBlock {
         display: flex;
         align-items: center;
@@ -282,8 +287,8 @@ export class AppHome extends LitElement {
           </div>
 
           <div id="cats">
-            <button class="${this.cat === null ? 'active' : null}" aria-pressed="${this.cat === null ? 'true' : 'false'}" @click=${this.doGetAll}>Components</button>
-            <button class="${this.cat === 'demos' ? 'active' : null}" aria-pressed="${this.cat === 'demos' ? 'true' : 'false'}" @click=${() => this.changeCat('demos')}>Demos</button>
+            <button class="${this.cat === null ? 'active' : null}" id="categoryButton" aria-pressed="${this.cat === null ? 'true' : 'false'}" @click=${this.doGetAll}>Components</button>
+            <button class="${this.cat === 'demos' ? 'active' : null}" id="categoryButton" aria-pressed="${this.cat === 'demos' ? 'true' : 'false'}" @click=${() => this.changeCat('demos')}>Demos</button>
           </div>
         </div>
 


### PR DESCRIPTION
Fix
https://github.com/pwa-builder/PWABuilder/issues/822

##PR Type
Accessibility Issue Fix

##Describe the current behavior?
Keyboard navigation by the 'Tab' key does not show a visual focus on the Header elements, and the Component and Demo keys.

##Describe the new behavior?
Keyboard navigation by the 'Tab' key now shows a focus box for the Header elements, and the Component and Demo keys.